### PR TITLE
Switch from inverse to negation for PriorityQueue of clusters

### DIFF
--- a/philharmonic/cluster_network.py
+++ b/philharmonic/cluster_network.py
@@ -140,14 +140,20 @@ def main(
         if n_clusters < 2:
             clustQ.put((-len(c), c))
             break
-
-        SC2 = SpectralClustering(
-            n_clusters=n_clusters,
-            assign_labels="discretize",
-            random_state=random_seed,
-            affinity="precomputed",
-        )
-        SC2.fit(sim[c, :][:, c])
+        i = 0
+        n_labels = 1
+        while n_labels == 1:
+            #if i > 0:
+            #    logger.info(f"Incremented random seed to {i} to fix a degenerate clustering")
+            SC2 = SpectralClustering(
+                n_clusters=n_clusters,
+                assign_labels="discretize",
+                random_state=random_seed+i,
+                affinity="precomputed",
+            )
+            SC2.fit(sim[c, :][:, c])
+            n_labels = len(set(SC2.labels_))
+            i += 1
 
         subClusts = extract_clusters(SC2, c, verbosity=2)
         for subClust in subClusts:

--- a/philharmonic/cluster_network.py
+++ b/philharmonic/cluster_network.py
@@ -48,7 +48,7 @@ def extract_clusters(
         logger.info(to_print[:-1])
 
     # return list of tuples of priority of cluster and list of nodes in cluster
-    return [(1 / len(subC), subC) for subC in subCs]
+    return [(-len(subC), subC) for subC in subCs]
 
 
 def read_network_subset(network_file, protein_names, output_stats=True):
@@ -125,14 +125,14 @@ def main(
     clusts.sort(key=lambda x: len(x), reverse=True)
 
     logger.info(f"Initial Clustering: {len(clusts)} clusters")
-    clustQ: PriorityQueue[tuple[float, list[int]]] = PriorityQueue()
+    clustQ: PriorityQueue[tuple[int, list[int]]] = PriorityQueue()
     for c in clusts:
-        clustQ.put((1 / len(c), c))
+        clustQ.put((-len(c), c))
 
     logger.info(f"Splitting large clusters into {cluster_divisor} clusters...")
     while True:
         priority, c = clustQ.get()
-        csize = int(1 / priority)
+        csize = -priority
 
         n_clusters = int(
             np.round(csize / cluster_divisor)


### PR DESCRIPTION
Spectral clusters are added to a priority queue based on the size of each cluster, with larger clusters having higher priority. Using the inverse of cluster size for priority can lead to off-by-one (smaller) sizes when recovering sizes from priorities. This switches to using negation of sizes, which is simpler and numerically stable. An alternative would be to remove the use of cluster sizes inferred from priorities.